### PR TITLE
Rename 'Enum' to 'EnumType' in EnumItem

### DIFF
--- a/src/classes/roblox/datatypes/enum.cpp
+++ b/src/classes/roblox/datatypes/enum.cpp
@@ -148,7 +148,7 @@ static int EnumItem__index(lua_State* L) {
         lua_pushstring(L, enum_item->name.c_str());
     else if (strequal(key, "Value"))
         lua_pushunsigned(L, enum_item->value);
-    else if (strequal(key, "Enum"))
+    else if (strequal(key, "EnumType"))
         pushEnum(L, enum_item->enum_name);
     else
         luaL_errorL(L, "%s is not a valid member of Enum.%s.%s", key, enum_item->enum_name.c_str(), enum_item->name.c_str());


### PR DESCRIPTION
There is no property named "Enum" in EnumItem according to the roblox documentation. I'm assuming you meant "EnumType"?
https://create.roblox.com/docs/reference/engine/datatypes/EnumItem#EnumType